### PR TITLE
fix in comparison when stencils are not in the same order

### DIFF
--- a/pyutils/perftest/result.py
+++ b/pyutils/perftest/result.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import json
-
+from collections import Counter
 import numpy as np
 
 from perftest import ArgumentError, logger, ParseError, time
@@ -193,7 +193,7 @@ def percentiles_by_stencil(results, percentiles):
         number of returned values depends on the number of input percentiles.
     """
     stencils = results[0].stencils
-    if any(stencils != r.stencils for r in results):
+    if any(Counter(stencils) != Counter(r.stencils) for r in results):
         raise ArgumentError('All results must include the same stencils')
 
     qtimes = []


### PR DESCRIPTION
fix in comparison when stencils in different json files are not in the same order